### PR TITLE
Enable music in recordings

### DIFF
--- a/src/IO/TrackRecorder.cs
+++ b/src/IO/TrackRecorder.cs
@@ -75,7 +75,7 @@ namespace linerider.IO
 
         public static bool Recording;
         public static bool Recording1080p;
-        public static void RecordTrack(MainWindow game, bool is1080P, bool smooth)
+        public static void RecordTrack(MainWindow game, bool is1080P, bool smooth, bool music)
         {
             Settings.Local.SmoothRecording = smooth;
             var flag = game.Track.GetFlag();
@@ -207,6 +207,15 @@ namespace linerider.IO
                         var parameters = new FFMPEGParameters();
                         parameters.AddOption("framerate", smooth ? "60" : "40");
                         parameters.AddOption("i", "\"" + dir + Path.DirectorySeparatorChar + "tmp%d.png" + "\"");
+                        if (music)
+                        {
+                            var fn = Program.UserDirectory + "Songs" +
+                                     Path.DirectorySeparatorChar +
+                                     Settings.Local.CurrentSong.Location;
+
+                            parameters.AddOption("i", "\"" + fn + "\"");
+                            parameters.AddOption("shortest");
+                        }
                         parameters.AddOption("vf", "vflip");//we save images upside down expecting ffmpeg to flip more efficiently.
                         parameters.AddOption("c:v", "libx264");
                         parameters.AddOption("preset", "veryfast");

--- a/src/UI/ExportVideoWindow.cs
+++ b/src/UI/ExportVideoWindow.cs
@@ -48,9 +48,9 @@ namespace linerider.UI
 
             popup.Container.Height += 50;
             var btn = popup.Container.FindChildByName("Okay");
-            btn.Margin = new Margin(btn.Margin.Left, btn.Margin.Top + 50, btn.Margin.Right, btn.Margin.Bottom);
+            btn.Margin = new Margin(btn.Margin.Left, btn.Margin.Top + (Settings.Local.EnableSong ? 70 : 50), btn.Margin.Right, btn.Margin.Bottom);
             btn = popup.Container.FindChildByName("Cancel");
-            btn.Margin = new Margin(btn.Margin.Left, btn.Margin.Top + 50, btn.Margin.Right, btn.Margin.Bottom);
+            btn.Margin = new Margin(btn.Margin.Left, btn.Margin.Top + (Settings.Local.EnableSong ? 70 : 50), btn.Margin.Right, btn.Margin.Bottom);
             popup.Layout();
             var radio = new RadioButtonGroup(popup.Container);
             radio.Name = "qualityselector";
@@ -65,8 +65,18 @@ namespace linerider.UI
             smooth.IsChecked = true;
             smooth.Text = "Smooth Playback";
             Align.AlignBottom(smooth);
+
+            LabeledCheckBox music = new LabeledCheckBox(popup.Container);
+            music.Name = "music";
+            music.IsChecked = Settings.Local.EnableSong;
+            music.IsHidden = !Settings.Local.EnableSong;
+            music.Text = "Include Music";
+            if (Settings.Local.EnableSong)
+            {
+                popup.Container.Height += 20;
+                Align.AlignBottom(music);
+            }
             popup.Layout();
-            //smooth.Y += 30;
 
             popup.SetPosition((game.RenderSize.Width / 2) - (popup.Width / 2), (game.RenderSize.Height / 2) - (popup.Height / 2));
 
@@ -84,7 +94,7 @@ namespace linerider.UI
                     {
                         var radiogrp = radio;
                         bool is1080p = radiogrp.Selected.Text == "1080p";
-                        IO.TrackRecorder.RecordTrack(game, is1080p, smooth.IsChecked);
+                        IO.TrackRecorder.RecordTrack(game, is1080p, smooth.IsChecked, music.IsChecked);
                     }
                 }
             };

--- a/src/UI/ExportVideoWindow.cs
+++ b/src/UI/ExportVideoWindow.cs
@@ -74,7 +74,7 @@ namespace linerider.UI
             if (Settings.Local.EnableSong)
             {
                 popup.Container.Height += 20;
-                Align.AlignBottom(music);
+                Align.PlaceDownLeft(music, smooth);
             }
             popup.Layout();
 


### PR DESCRIPTION
If a song is enabled for the current track, the recording window gains an additional checkbox labeled "Include Music", that does exactly what it says.

The way I included that checkbox feels super hacky but I don't know how this UI code works ¯\\\_(ツ)_/¯

Resolves #14 