### PR TITLE
Save render-related options when user clicks OK

### DIFF
--- a/src/UI/ExportVideoWindow.cs
+++ b/src/UI/ExportVideoWindow.cs
@@ -72,7 +72,7 @@ namespace linerider.UI
             }
             LabeledCheckBox smooth = new LabeledCheckBox(popup.Container);
             smooth.Name = "smooth";
-            smooth.IsChecked = true;
+            smooth.IsChecked = Settings.RenderSmooth;
             smooth.Text = "Smooth Playback";
             Align.AlignBottom(smooth);
 
@@ -110,7 +110,9 @@ namespace linerider.UI
                     {
                         var radiogrp = radio;
                         bool is1080p = radiogrp.Selected.Text == "1080p";
+
                         Settings.Render1080p = is1080p;
+                        Settings.RenderSmooth = smooth.IsChecked;
                         Settings.Save();
                         IO.TrackRecorder.RecordTrack(game, is1080p, smooth.IsChecked, music.IsChecked);
                     }

--- a/src/UI/ExportVideoWindow.cs
+++ b/src/UI/ExportVideoWindow.cs
@@ -55,7 +55,7 @@ namespace linerider.UI
             var radio = new RadioButtonGroup(popup.Container);
             radio.Name = "qualityselector";
 
-            if (Settings.Render1080p)
+            if (Settings.Record108p)
             {
                 radio.AddOption("720p");
                 radio.AddOption("1080p").Select();
@@ -72,13 +72,13 @@ namespace linerider.UI
             }
             LabeledCheckBox smooth = new LabeledCheckBox(popup.Container);
             smooth.Name = "smooth";
-            smooth.IsChecked = Settings.RenderSmooth;
+            smooth.IsChecked = Settings.RecordSmooth;
             smooth.Text = "Smooth Playback";
             Align.AlignBottom(smooth);
 
             LabeledCheckBox music = new LabeledCheckBox(popup.Container);
             music.Name = "music";
-            music.IsChecked = Settings.Local.EnableSong && Settings.RenderMusic;
+            music.IsChecked = Settings.Local.EnableSong && Settings.RecordMusic;
             music.IsHidden = !Settings.Local.EnableSong;
             music.Text = "Include Music";
             if (Settings.Local.EnableSong)
@@ -97,11 +97,11 @@ namespace linerider.UI
                     var radiogrp = radio;
                     bool is1080p = radiogrp.Selected.Text == "1080p";
 
-                    Settings.Render1080p = is1080p;
-                    Settings.RenderSmooth = smooth.IsChecked;
+                    Settings.Record108p = is1080p;
+                    Settings.RecordSmooth = smooth.IsChecked;
                     if (Settings.Local.EnableSong)
                     {
-                        Settings.RenderMusic = music.IsChecked;
+                        Settings.RecordMusic = music.IsChecked;
                     }
                     Settings.Save();
 

--- a/src/UI/ExportVideoWindow.cs
+++ b/src/UI/ExportVideoWindow.cs
@@ -94,6 +94,17 @@ namespace linerider.UI
             {
                 if (popup.Result == System.Windows.Forms.DialogResult.OK)
                 {
+                    var radiogrp = radio;
+                    bool is1080p = radiogrp.Selected.Text == "1080p";
+
+                    Settings.Render1080p = is1080p;
+                    Settings.RenderSmooth = smooth.IsChecked;
+                    if (Settings.Local.EnableSong)
+                    {
+                        Settings.RenderMusic = music.IsChecked;
+                    }
+                    Settings.Save();
+
                     if (game.Track.GetFlag() == null)
                     {
                         var pop = PopupWindow.Create(
@@ -108,16 +119,6 @@ namespace linerider.UI
                     }
                     else
                     {
-                        var radiogrp = radio;
-                        bool is1080p = radiogrp.Selected.Text == "1080p";
-
-                        Settings.Render1080p = is1080p;
-                        Settings.RenderSmooth = smooth.IsChecked;
-                        if (Settings.Local.EnableSong)
-                        {
-                            Settings.RenderMusic = music.IsChecked;
-                        }
-                        Settings.Save();
                         IO.TrackRecorder.RecordTrack(game, is1080p, smooth.IsChecked, music.IsChecked);
                     }
                 }

--- a/src/UI/ExportVideoWindow.cs
+++ b/src/UI/ExportVideoWindow.cs
@@ -54,8 +54,18 @@ namespace linerider.UI
             popup.Layout();
             var radio = new RadioButtonGroup(popup.Container);
             radio.Name = "qualityselector";
-            radio.AddOption("720p").Select();
-            radio.AddOption("1080p");
+
+            if (Settings.Render1080p)
+            {
+                radio.AddOption("720p");
+                radio.AddOption("1080p").Select();
+            }
+            else
+            {
+                radio.AddOption("720p").Select();
+                radio.AddOption("1080p");
+            }
+            
             if (!SafeFrameBuffer.CanRecord)
             {
                 radio.IsHidden = true;
@@ -100,6 +110,8 @@ namespace linerider.UI
                     {
                         var radiogrp = radio;
                         bool is1080p = radiogrp.Selected.Text == "1080p";
+                        Settings.Render1080p = is1080p;
+                        Settings.Save();
                         IO.TrackRecorder.RecordTrack(game, is1080p, smooth.IsChecked, music.IsChecked);
                     }
                 }

--- a/src/UI/ExportVideoWindow.cs
+++ b/src/UI/ExportVideoWindow.cs
@@ -78,7 +78,7 @@ namespace linerider.UI
 
             LabeledCheckBox music = new LabeledCheckBox(popup.Container);
             music.Name = "music";
-            music.IsChecked = Settings.Local.EnableSong;
+            music.IsChecked = Settings.Local.EnableSong && Settings.RenderMusic;
             music.IsHidden = !Settings.Local.EnableSong;
             music.Text = "Include Music";
             if (Settings.Local.EnableSong)
@@ -113,6 +113,10 @@ namespace linerider.UI
 
                         Settings.Render1080p = is1080p;
                         Settings.RenderSmooth = smooth.IsChecked;
+                        if (Settings.Local.EnableSong)
+                        {
+                            Settings.RenderMusic = music.IsChecked;
+                        }
                         Settings.Save();
                         IO.TrackRecorder.RecordTrack(game, is1080p, smooth.IsChecked, music.IsChecked);
                     }

--- a/src/Utils/Settings.cs
+++ b/src/Utils/Settings.cs
@@ -72,6 +72,7 @@ namespace linerider
         public static bool CheckForUpdates = true;
         public static bool Render1080p = false;
         public static bool RenderSmooth = true;
+        public static bool RenderMusic = true;
         public static string LastSelectedTrack = "";
         static Settings()
         {
@@ -182,6 +183,7 @@ namespace linerider
             LoadBool(GetSetting(lines, nameof(RoundLegacyCamera)), ref RoundLegacyCamera);
             LoadBool(GetSetting(lines, nameof(Render1080p)), ref Render1080p);
             LoadBool(GetSetting(lines, nameof(RenderSmooth)), ref RenderSmooth);
+            LoadBool(GetSetting(lines, nameof(RenderMusic)), ref RenderMusic);
             var lasttrack = GetSetting(lines, nameof(LastSelectedTrack));
             if (File.Exists(lasttrack) && lasttrack.StartsWith(Constants.TracksDirectory))
             {
@@ -209,6 +211,7 @@ namespace linerider
             config += "\r\n" + MakeSetting(nameof(RoundLegacyCamera), RoundLegacyCamera.ToString(Program.Culture));
             config += "\r\n" + MakeSetting(nameof(Render1080p), Render1080p.ToString(Program.Culture));
             config += "\r\n" + MakeSetting(nameof(RenderSmooth), RenderSmooth.ToString(Program.Culture));
+            config += "\r\n" + MakeSetting(nameof(RenderMusic), RenderMusic.ToString(Program.Culture));
             foreach (var binds in Keybinds)
             {
                 foreach (var bind in binds.Value)

--- a/src/Utils/Settings.cs
+++ b/src/Utils/Settings.cs
@@ -70,6 +70,7 @@ namespace linerider
         public static bool RoundLegacyCamera = true;
         public static bool SmoothPlayback = true;
         public static bool CheckForUpdates = true;
+        public static bool Render1080p = false;
         public static string LastSelectedTrack = "";
         static Settings()
         {
@@ -178,6 +179,7 @@ namespace linerider
             LoadBool(GetSetting(lines, nameof(CheckForUpdates)), ref CheckForUpdates);
             LoadBool(GetSetting(lines, nameof(SmoothPlayback)), ref SmoothPlayback);
             LoadBool(GetSetting(lines, nameof(RoundLegacyCamera)), ref RoundLegacyCamera);
+            LoadBool(GetSetting(lines, nameof(Render1080p)), ref Render1080p);
             var lasttrack = GetSetting(lines, nameof(LastSelectedTrack));
             if (File.Exists(lasttrack) && lasttrack.StartsWith(Constants.TracksDirectory))
             {
@@ -203,6 +205,7 @@ namespace linerider
             config += "\r\n" + MakeSetting(nameof(SmoothPlayback), SmoothPlayback.ToString(Program.Culture));
             config += "\r\n" + MakeSetting(nameof(LastSelectedTrack), LastSelectedTrack);
             config += "\r\n" + MakeSetting(nameof(RoundLegacyCamera), RoundLegacyCamera.ToString(Program.Culture));
+            config += "\r\n" + MakeSetting(nameof(Render1080p), Render1080p.ToString(Program.Culture));
             foreach (var binds in Keybinds)
             {
                 foreach (var bind in binds.Value)

--- a/src/Utils/Settings.cs
+++ b/src/Utils/Settings.cs
@@ -71,6 +71,7 @@ namespace linerider
         public static bool SmoothPlayback = true;
         public static bool CheckForUpdates = true;
         public static bool Render1080p = false;
+        public static bool RenderSmooth = true;
         public static string LastSelectedTrack = "";
         static Settings()
         {
@@ -180,6 +181,7 @@ namespace linerider
             LoadBool(GetSetting(lines, nameof(SmoothPlayback)), ref SmoothPlayback);
             LoadBool(GetSetting(lines, nameof(RoundLegacyCamera)), ref RoundLegacyCamera);
             LoadBool(GetSetting(lines, nameof(Render1080p)), ref Render1080p);
+            LoadBool(GetSetting(lines, nameof(RenderSmooth)), ref RenderSmooth);
             var lasttrack = GetSetting(lines, nameof(LastSelectedTrack));
             if (File.Exists(lasttrack) && lasttrack.StartsWith(Constants.TracksDirectory))
             {
@@ -206,6 +208,7 @@ namespace linerider
             config += "\r\n" + MakeSetting(nameof(LastSelectedTrack), LastSelectedTrack);
             config += "\r\n" + MakeSetting(nameof(RoundLegacyCamera), RoundLegacyCamera.ToString(Program.Culture));
             config += "\r\n" + MakeSetting(nameof(Render1080p), Render1080p.ToString(Program.Culture));
+            config += "\r\n" + MakeSetting(nameof(RenderSmooth), RenderSmooth.ToString(Program.Culture));
             foreach (var binds in Keybinds)
             {
                 foreach (var bind in binds.Value)

--- a/src/Utils/Settings.cs
+++ b/src/Utils/Settings.cs
@@ -70,9 +70,9 @@ namespace linerider
         public static bool RoundLegacyCamera = true;
         public static bool SmoothPlayback = true;
         public static bool CheckForUpdates = true;
-        public static bool Render1080p = false;
-        public static bool RenderSmooth = true;
-        public static bool RenderMusic = true;
+        public static bool Record108p = false;
+        public static bool RecordSmooth = true;
+        public static bool RecordMusic = true;
         public static string LastSelectedTrack = "";
         static Settings()
         {
@@ -181,9 +181,9 @@ namespace linerider
             LoadBool(GetSetting(lines, nameof(CheckForUpdates)), ref CheckForUpdates);
             LoadBool(GetSetting(lines, nameof(SmoothPlayback)), ref SmoothPlayback);
             LoadBool(GetSetting(lines, nameof(RoundLegacyCamera)), ref RoundLegacyCamera);
-            LoadBool(GetSetting(lines, nameof(Render1080p)), ref Render1080p);
-            LoadBool(GetSetting(lines, nameof(RenderSmooth)), ref RenderSmooth);
-            LoadBool(GetSetting(lines, nameof(RenderMusic)), ref RenderMusic);
+            LoadBool(GetSetting(lines, nameof(Record108p)), ref Record108p);
+            LoadBool(GetSetting(lines, nameof(RecordSmooth)), ref RecordSmooth);
+            LoadBool(GetSetting(lines, nameof(RecordMusic)), ref RecordMusic);
             var lasttrack = GetSetting(lines, nameof(LastSelectedTrack));
             if (File.Exists(lasttrack) && lasttrack.StartsWith(Constants.TracksDirectory))
             {
@@ -209,9 +209,9 @@ namespace linerider
             config += "\r\n" + MakeSetting(nameof(SmoothPlayback), SmoothPlayback.ToString(Program.Culture));
             config += "\r\n" + MakeSetting(nameof(LastSelectedTrack), LastSelectedTrack);
             config += "\r\n" + MakeSetting(nameof(RoundLegacyCamera), RoundLegacyCamera.ToString(Program.Culture));
-            config += "\r\n" + MakeSetting(nameof(Render1080p), Render1080p.ToString(Program.Culture));
-            config += "\r\n" + MakeSetting(nameof(RenderSmooth), RenderSmooth.ToString(Program.Culture));
-            config += "\r\n" + MakeSetting(nameof(RenderMusic), RenderMusic.ToString(Program.Culture));
+            config += "\r\n" + MakeSetting(nameof(Record108p), Record108p.ToString(Program.Culture));
+            config += "\r\n" + MakeSetting(nameof(RecordSmooth), RecordSmooth.ToString(Program.Culture));
+            config += "\r\n" + MakeSetting(nameof(RecordMusic), RecordMusic.ToString(Program.Culture));
             foreach (var binds in Keybinds)
             {
                 foreach (var bind in binds.Value)


### PR DESCRIPTION
Clearly those are options the user likes, might as well present them already in that configuration the next time they go to render a track.

When opening the video export window, the resolution and the Smooth Playback toggle are automatically filled in with the same settings the user had last time they clicked OK.

The same is *almost* true for the Include Music toggle. When opening the video export window **and the current track has an associated song**, the Include Music toggle is automatically filled in with the same setting the user had last time they clicked OK **while rendering a track that had an associated song**.