### PR TITLE
Fix the tooltips for hand button and start button.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,10 +4,5 @@
 **/.vs
 **/obj
 **/packages
-build/*.exe
-build/*.mdb
-build/*.xml
-build/*.config
-build/*.pdb
-build/*.dll
+build
 deploy

--- a/src/UI/Widgets/Toolbar.cs
+++ b/src/UI/Widgets/Toolbar.cs
@@ -1,7 +1,7 @@
 ﻿//  Author:
 //       Noah Ablaseau <nablaseau@hotmail.com>
 //
-//  Copyright (c) 2017 
+//  Copyright (c) 2017
 //
 //  This program is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by
@@ -68,8 +68,8 @@ namespace linerider.UI
             _linebtn = CreateTool(GameResources.line_icon, "Line Tool (W)");
             _eraserbtn = CreateTool(GameResources.eraser_icon, "Eraser Tool (E)");
             _selectbtn = CreateTool(GameResources.movetool_icon, "Select Tool (R)");
-            _handbtn = CreateTool(GameResources.pantool_icon, "Hand Tool (Space) (T)");
-            _start = CreateTool(GameResources.play_icon, "Start (Y)");
+            _handbtn = CreateTool(GameResources.pantool_icon, "Hand Tool (Shift+Space) (T)");
+            _start = CreateTool(GameResources.play_icon, "Start (Space) (Y)");
             _pause = CreateTool(GameResources.pause, "Pause (Space)");
             _stop = CreateTool(GameResources.stop_icon, "Stop (U)");
             _flag = CreateTool(GameResources.flag_icon, "Flag (I)");


### PR DESCRIPTION
### :dart: What is the goal?

To correct an error in the button tool-tips. The move/hand-tool button had `(Space)` incorrectly listed as a shortcut key (should be `(Shift+Space)`), and the play-tool button did not list `(Space)`.

### :hammer_and_wrench: How is it being implemented?

Simple text-changes to the tool-tip strings when passed into `CreateTool`.

### :boom: How can it be tested?

Hover the mouse over the move/hand tool button, ensure `(Shift+Space)` is present in the tool-tip, in addition to `(T)`.
Hover the mouse over the play tool, ensure that `(Space)` is listed in the tool-tip, in addition to `(Y)`.

### :gift_heart: Additional changes

Ignore entire `build` directory.